### PR TITLE
Reject on expired cache when rejectOnNull is set

### DIFF
--- a/FileCacheSimple.js
+++ b/FileCacheSimple.js
@@ -45,6 +45,8 @@ FileCacheSimple.prototype.get = function(key) {
 				let currentTime = (new Date()).getTime();
 				let cacheExpire = (cache.cacheExpire) ? cache.cacheExpire : self._options.cacheExpire;
 				if(currentTime - cache.cachedOn >= cacheExpire) {
+					if(self._options.rejectOnNull)
+						return reject();
 					return resolve(null);
 				}
 				return resolve(cache.content);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-cache-simple",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Simple file caching",
   "main": "FileCacheSimple.js",
   "scripts": {
@@ -18,7 +18,8 @@
   ],
   "author": "Michiel van der Velde <michiel@michielvdvelde.nl>",
   "contributors": [{
-    "name": "gregorskii"
+    "name": "gregorskii",
+    "name": "TomTom101"
   }],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
I was debugging a situation where data is either loaded from cache, or from a server if no cached data is available. My cache(get).then() case handles expects cached data, no matter whether it is expired or not available at all. I actually expected rejectOnNull to handle both cases. It does now, I personally find it much more intuitive. Best, t