### PR TITLE
Do not modify default options when creating object

### DIFF
--- a/FileCacheSimple.js
+++ b/FileCacheSimple.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const jetpack = require('fs-jetpack');
-const extend = require('extend');
 
 const path = require('path');
 const util = require('util');
@@ -15,7 +14,7 @@ const DEFAULT_OPTIONS = {
 };
 
 let FileCacheSimple = function(options) {
-	this._options = (options) ? extend(true, DEFAULT_OPTIONS, options) : DEFAULT_OPTIONS;
+	this._options = Object.assign({}, DEFAULT_OPTIONS, options);
 	this._fs = jetpack.cwd(this._options.cacheDir);
 };
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/MichielvdVelde/file-cache-simple#readme",
   "dependencies": {
-    "extend": "^3.0.0",
     "fs-jetpack": "^0.7.1"
   }
 }


### PR DESCRIPTION
extend() was modifying the DEFAULT_OPTIONS. A program
creating more than one instances of this cache (for example
with different prefixes) would find unexpected results.

Use Object.assign from vanilla JS which works as expected
and remove the external dependency on the "expect" module.