### PR TITLE
Update fs-jetpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/MichielvdVelde/file-cache-simple#readme",
   "dependencies": {
-    "fs-jetpack": "^0.7.1"
+    "fs-jetpack": "^2.2.2"
   }
 }


### PR DESCRIPTION
https://www.npmjs.com/advisories/118

fs-jetpack used to include a vulnerable version of minimatch. It is no longer the case.
Updating package.json.